### PR TITLE
Updates to support Maps and Sets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,9 @@ export function clone<T>(input: T): T {
 
 	} else if (isPlainObject(input)) {
 
+		if (input instanceof Map || input instanceof Set)
+			return input;
+		  
 		const output: any = {}
 
 		for (let index in input)

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ function _recursiveMerge(base: any, extend: any) {
 		return extend
 
 	for (const key in extend) {
-		if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype' || key === 'toString' || key === 'hasOwnProperty') continue
 		base[key] = (isPlainObject(base[key]) && isPlainObject(extend[key])) ?
 			_recursiveMerge(base[key], extend[key]) :
 			extend[key]
@@ -90,7 +90,7 @@ function _merge(isClone: boolean, isRecursive: boolean, items: any[]) {
 			continue
 
 		for (const key in item) {
-			if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
+			if (key === '__proto__' || key === 'constructor' || key === 'prototype' || key === 'toString' || key === 'hasOwnProperty') continue
 			const value = isClone ? clone(item[key]) : item[key]
 			result[key] = isRecursive ? _recursiveMerge(result[key], value) : value
 		}


### PR DESCRIPTION
Treating them as an abstract data type which should not be cloned
https://stackoverflow.com/questions/30626070/shallow-clone-a-map-or-set#comment72065146_30626071

and also prevents Prototype Pollution of `toString` and `hasOwnProperty`